### PR TITLE
Fixed No Certificate Bug

### DIFF
--- a/Dataset_Preprocess.ipynb
+++ b/Dataset_Preprocess.ipynb
@@ -63,7 +63,7 @@
     }
    ],
    "source": [
-    "! curl https://archive.ics.uci.edu/ml/machine-learning-databases/00421/aps_failure_training_set.csv --output aps_failure_training_set.csv"
+    "! curl --insecure https://archive.ics.uci.edu/ml/machine-learning-databases/00421/aps_failure_training_set.csv --output aps_failure_training_set.csv"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
UCI's archive's HTTPS certificate is out of date causing curl to error out before downloading dataset. Adding `--insecure` fixes this issue allowing the dataset to be downloaded.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
